### PR TITLE
Small _FD_STOP_PRINT fix

### DIFF
--- a/fd-macros/mainsail-support.cfg
+++ b/fd-macros/mainsail-support.cfg
@@ -137,9 +137,9 @@ description: Common code for cancel/end print
 gcode:
   SAVE_GCODE_STATE NAME=_fd_stop_print_state 
 
-  {% set STOP_X = printer.toolhead.position.x + 10.0 | float %}
+  {% set STOP_X = printer.toolhead.position.x + 2.0 | float %}
   {% set STOP_Y = printer.toolhead.position.y + 2.0 | float %}
-  {% set STOP_Z = printer.toolhead.position.z + 2.0 | float %}
+  {% set STOP_Z = printer.toolhead.position.z + 10.0 | float %}
 
   {% if STOP_X > printer.toolhead.axis_maximum.x %}
     {% set STOP_X = printer.toolhead.axis_maximum.x %}


### PR DESCRIPTION
The toolhead was moving by x+10,y+2,z+2 but it intended to be x+2,y+2,z+10

Signed-off-by: Frank Roth developer@freakydu.de