### PR TITLE
Improved progress

### DIFF
--- a/fd-macros/bigtreetech-support.cfg
+++ b/fd-macros/bigtreetech-support.cfg
@@ -32,6 +32,7 @@ gcode:
 [gcode_macro M73]
 rename_existing: M73.1
 variable_last_minutes: 0.0
+variable_progress_supported: false
 gcode: 
   {% set PROGRESS = params.P | default(0.0) | float  %}
   {% set MINUTES = params.R | default(0.0) | float  %}
@@ -47,6 +48,11 @@ gcode:
       SET_GCODE_VARIABLE MACRO=M73 VARIABLE=last_minutes VALUE={MINUTES}
     {% endif %}     
   {% endif %}
+
+  {% if params.P is defined %}
+    SET_GCODE_VARIABLE MACRO=M73 VARIABLE=progress_supported VALUE={true}
+    _BTT_NOTIFY_DATALEFT CURRENT={PROGRESS * 100.0 | default(0) | int} MAX={100*100 | int}
+  {% endif %}  
 
   M73.1 {rawparams}
 

--- a/fd-macros/bigtreetech-support.cfg
+++ b/fd-macros/bigtreetech-support.cfg
@@ -32,7 +32,7 @@ gcode:
 [gcode_macro M73]
 rename_existing: M73.1
 variable_last_minutes: 0.0
-variable_progress_supported: false
+variable_progress_supported: 0
 gcode: 
   {% set PROGRESS = params.P | default(0.0) | float  %}
   {% set MINUTES = params.R | default(0.0) | float  %}
@@ -50,7 +50,7 @@ gcode:
   {% endif %}
 
   {% if params.P is defined %}
-    SET_GCODE_VARIABLE MACRO=M73 VARIABLE=progress_supported VALUE={true}
+    SET_GCODE_VARIABLE MACRO=M73 VARIABLE=progress_supported VALUE="1"
     _BTT_NOTIFY_DATALEFT CURRENT={PROGRESS * 100.0 | default(0) | int} MAX={100*100 | int}
   {% endif %}  
 

--- a/fd-macros/bigtreetech-support.cfg
+++ b/fd-macros/bigtreetech-support.cfg
@@ -15,8 +15,8 @@ description: Report SD print status
 rename_existing: M27.1
 variable_last_interval: 0
 gcode:
-  {% set INTERVAL = params.S | default(0) | float  %} #Interval between auto-reports. S0 to disable.
-  {% set FILE = params.C   %} #Interval between auto-reports. S0 to disable.
+  {% set INTERVAL = params.S | default(0) | float %} #Interval between auto-reports. S0 to disable.
+  {% set FILE = params.C %} #Interval between auto-reports. S0 to disable.
 
   M27.1 {rawparams}
 
@@ -34,8 +34,8 @@ rename_existing: M73.1
 variable_last_minutes: 0.0
 variable_progress_supported: 0
 gcode: 
-  {% set PROGRESS = params.P | default(0.0) | float  %}
-  {% set MINUTES = params.R | default(0.0) | float  %}
+  {% set PROGRESS = params.P | default(0.0) | float %}
+  {% set MINUTES = params.R | default(0.0) | float %}
 
   {% if last_minutes != MINUTES %} # update display timeleft only if input changed
     {% set MINUTES_FLOOR = MINUTES | round(0,'floor' ) | int %}
@@ -50,7 +50,7 @@ gcode:
   {% endif %}
 
   {% if params.P is defined %}
-    SET_GCODE_VARIABLE MACRO=M73 VARIABLE=progress_supported VALUE="1"
+    SET_GCODE_VARIABLE MACRO=M73 VARIABLE=progress_supported VALUE=1
     _BTT_NOTIFY_DATALEFT CURRENT={PROGRESS * 100.0 | default(0) | int} MAX={100*100 | int}
   {% endif %}  
 
@@ -125,14 +125,14 @@ description: Serial print and parse BTT TouchScreenFirmware
   Send a message to the connected host for display in the host console or to perform a host action.
 rename_existing: M118.1
 gcode:
-  {% set P = params.P | default(0) | int  %}
-  {% set A = params.A | default(0) | int  %}
-  {% set ACTION = params.ACTION | string  %}
-  {% set NOTIFICATION = params.NOTIFICATION | string  %}
-  {% set REMOTE = params.REMOTE | string  %}
-  {% set PAUSE = params.PAUSE | string  %}
-  {% set RESUME = params.RESUME | string  %}
-  {% set CANCEL = params.CANCEL | string  %}
+  {% set P = params.P | default(0) | int %}
+  {% set A = params.A | default(0) | int %}
+  {% set ACTION = params.ACTION | string %}
+  {% set NOTIFICATION = params.NOTIFICATION | string %}
+  {% set REMOTE = params.REMOTE | string %}
+  {% set PAUSE = params.PAUSE | string %}
+  {% set RESUME = params.RESUME | string %}
+  {% set CANCEL = params.CANCEL | string %}
 
   {% if A == 1 and params.ACTION is defined and params.NOTIFICATION is defined and params.REMOTE is defined %}    
     {% if params.PAUSE is defined %}
@@ -152,14 +152,14 @@ gcode:
 description: Set RGB(W) Color
   If you have an RGB(W) light, either as part of a controller or installed separately, the M150 command can be used to set its color.
 gcode:
-  {% set INDEX = params.I | default(0)| int  %}
-  {% set STRIPE = params.S | default(0)| int  %}
-  {% set KEEP = params.K | default(0)| int  %}
-  {% set RED = params.R | default(0)| int  %}
-  {% set GREEN = params.U | default(0)| int  %}
-  {% set BLUE = params.B | default(0)| int  %}
-  {% set WHITE = params.W | default(0)| int  %}
-  {% set BRIGHTNESS = params.P | default(255)| int  %}
+  {% set INDEX = params.I | default(0)| int %}
+  {% set STRIPE = params.S | default(0)| int %}
+  {% set KEEP = params.K | default(0)| int %}
+  {% set RED = params.R | default(0)| int %}
+  {% set GREEN = params.U | default(0)| int %}
+  {% set BLUE = params.B | default(0)| int %}
+  {% set WHITE = params.W | default(0)| int %}
+  {% set BRIGHTNESS = params.P | default(255)| int %}
   
   SET_LED LED=extruder RED={(RED / 255 * BRIGHTNESS / 255) | float} GREEN={(GREEN / 255 * BRIGHTNESS / 255) | float} BLUE={(BLUE / 255 * BRIGHTNESS / 255) | float } WHITE={(WHITE / 255 * BRIGHTNESS / 255) | float} TRANSMIT=1 SYNC=1 # [INDEX=<index>] 
 
@@ -167,7 +167,7 @@ gcode:
 description: Position Auto-Report
 variable_last_interval: 0
 gcode:
-  {% set INTERVAL = params.S | default(0) | float  %}
+  {% set INTERVAL = params.S | default(0) | float %}
 
   SET_GCODE_VARIABLE MACRO=M154 VARIABLE=last_interval VALUE={INTERVAL}
   UPDATE_DELAYED_GCODE ID=_POS_AUTO_REPORT DURATION={INTERVAL}
@@ -176,7 +176,7 @@ gcode:
 description: Temperature Auto-Report
 variable_last_interval: 0
 gcode:
-  {% set INTERVAL = params.S | default(0) | float  %}
+  {% set INTERVAL = params.S | default(0) | float %}
 
   SET_GCODE_VARIABLE MACRO=M155 VARIABLE=last_interval VALUE={INTERVAL}
   UPDATE_DELAYED_GCODE ID=_TEMP_AUTO_REPORT DURATION={INTERVAL}
@@ -185,10 +185,10 @@ gcode:
 description: Print Move Limits
   Set the max acceleration for one or more axes (in current units-per-second squared)
 gcode:
-  {% set X = params.X | default(0)| float  %} #X axis max acceleration
-  {% set Y = params.Y | default(0)| float  %} #Y axis max acceleration
-  #{% set Z = params.Z | default(0)| float  %} #Z axis max acceleration
-  #{% set E = params.E | default(0)| float  %} #E axis max acceleration
+  {% set X = params.X | default(0)| float %} #X axis max acceleration
+  {% set Y = params.Y | default(0)| float %} #Y axis max acceleration
+  #{% set Z = params.Z | default(0)| float %} #Z axis max acceleration
+  #{% set E = params.E | default(0)| float %} #E axis max acceleration
 
   {% if params.X is defined %}
     SET_VELOCITY_LIMIT ACCEL={X} ACCEL_TO_DECEL={X * 2 / 3}
@@ -200,10 +200,10 @@ gcode:
 description: Set Max Feedrate
   Set the max feedrate for one or more axes (in current units-per-second).
 gcode:
-  {% set X = params.X | default(0)| float  %} #X axis max feedrate 
-  {% set Y = params.Y | default(0)| float  %} #Y axis max feedrate 
-  #{% set Z = params.Z | default(printer.configfile.settings.printer.max_z_velocity)| float  %} #Z axis max feedrate 
-  #{% set E = params.E | default(printer.configfile.settings.extruder.max_extrude_only_velocity)| float  %} #E axis max feedrate 
+  {% set X = params.X | default(0)| float %} #X axis max feedrate 
+  {% set Y = params.Y | default(0)| float %} #Y axis max feedrate 
+  #{% set Z = params.Z | default(printer.configfile.settings.printer.max_z_velocity)| float %} #Z axis max feedrate 
+  #{% set E = params.E | default(printer.configfile.settings.extruder.max_extrude_only_velocity)| float %} #E axis max feedrate 
 
   {% if params.X is defined %}
     SET_VELOCITY_LIMIT VELOCITY={X} 
@@ -243,8 +243,8 @@ gcode:
 description: Servo Position
   Set or get the position of a servo.
 gcode:
-  {% set INDEX = params.P | default(0)| int %}
-  {% set POS = params.S | default(0)| int %}
+  {% set INDEX = params.P | default(0) | int %}
+  {% set POS = params.S | default(0) | int %}
 
   {% if POS == 10 %} # Deploy
     BLTOUCH_DEBUG COMMAND=pin_down
@@ -281,9 +281,9 @@ gcode:
 description: PID autotune
   This command initiates a process of heating and cooling to determine the proper PID values for the specified hotend or the heated bed.
 gcode:
-  {% set INDEX = params.E | default(0)| int  %}
-  {% set COUNT = params.C | default(0)| int  %}
-  {% set SAVE = params.U | default(0)| int  %}
+  {% set INDEX = params.E | default(0)| int %}
+  {% set COUNT = params.C | default(0)| int %}
+  {% set SAVE = params.U | default(0)| int %}
   {% set TARGETTEMP = params.S | default(0)| float %}
 
   {% set HEATER = "extruder" %}
@@ -302,7 +302,7 @@ description: Bed Leveling State
   Get and/or set bed leveling state. For mesh-based leveling systems use Z parameter to set the Z Fade Height.
   With AUTO_BED_LEVELING_UBL you can use L to load a mesh from EEPROM.
 gcode:
-  {% set S = params.S | default(0)| int  %}
+  {% set S = params.S | default(0)| int %}
 
   {% if S == 1 %}
     BED_MESH_PROFILE LOAD=default
@@ -425,10 +425,10 @@ description: Sends to the BigTreeTech TouchScreenFirmware
   Use paremter MESSAGE to send a user message
   Use paremter ERROR to send a user error
 gcode:
-  {% set COMMAND = params.COMMAND | string  %}
-  {% set ACTION = params.ACTION | string  %}
-  {% set MESSAGE = params.MESSAGE | string  %}
-  {% set ERROR = params.ERROR | string  %}
+  {% set COMMAND = params.COMMAND | string %}
+  {% set ACTION = params.ACTION | string %}
+  {% set MESSAGE = params.MESSAGE | string %}
+  {% set ERROR = params.ERROR | string %}
 
   {% if params.COMMAND is defined %}
     RESPOND PREFIX="{COMMAND}"
@@ -462,19 +462,19 @@ gcode:
 
 [gcode_macro _BTT_NOTIFY_TIMELEFT]
 gcode:
-  {% set TIMELEFT = params.TIMELEFT | default("00h00m00s") | string  %}
+  {% set TIMELEFT = params.TIMELEFT | default("00h00m00s") | string %}
   _SEND_TO_BTT ACTION="{"notification Time Left " ~ TIMELEFT}"
 
 [gcode_macro _BTT_NOTIFY_LAYERLEFT]
 gcode:
-  {% set CURRENT_LAYER = params.CURRENT | default(0) | int  %}
-  {% set MAX_LAYER = params.MAX | default(0) | int  %}
+  {% set CURRENT_LAYER = params.CURRENT | default(0) | int %}
+  {% set MAX_LAYER = params.MAX | default(0) | int %}
   _SEND_TO_BTT ACTION="{"notification Layer Left " ~ CURRENT_LAYER ~ "/" ~ MAX_LAYER}"
 
 [gcode_macro _BTT_NOTIFY_DATALEFT]
 gcode:
-  {% set CURRENT_DATA = params.CURRENT | default(0) | int  %}
-  {% set MAX_DATA = params.MAX | default(0) | int  %}
+  {% set CURRENT_DATA = params.CURRENT | default(0) | int %}
+  {% set MAX_DATA = params.MAX | default(0) | int %}
 
   _SEND_TO_BTT ACTION="{"notification Data Left " ~ CURRENT_DATA ~ "/" ~ MAX_DATA}"
 

--- a/fd-macros/mainsail-support.cfg
+++ b/fd-macros/mainsail-support.cfg
@@ -64,13 +64,13 @@ gcode:
 
   {% if params.CURRENT_LAYER is defined %}
     _BTT_NOTIFY_LAYERLEFT CURRENT={CURRENT_LAYER} MAX={printer.print_stats.info.total_layer | default(0) | int}
-  {% endif %}
 
-  {% if not printer["gcode_macro M73"].progress_supported %}
-    {% if printer.virtual_sdcard.file_size is defined and printer.virtual_sdcard.file_size > 0 %}
-      _BTT_NOTIFY_DATALEFT CURRENT={printer.virtual_sdcard.file_position | default(0) | int} MAX={printer.virtual_sdcard.file_size | default(0) | int}
-    {% endif %} 
-  {% endif %} 
+    {% if printer["gcode_macro M73"].progress_supported == 0 %}
+      {% if printer.virtual_sdcard.file_size is defined and printer.virtual_sdcard.file_size > 0 %}
+        _BTT_NOTIFY_DATALEFT CURRENT={printer.virtual_sdcard.file_position | default(0) | int} MAX={printer.virtual_sdcard.file_size | default(0) | int}
+      {% endif %} 
+    {% endif %}   
+  {% endif %}
 
 [gcode_macro _FD_PAUSE]
 description: Internal
@@ -125,7 +125,7 @@ description: Internal
 gcode:
   # Reset states
   CLEAR_PAUSE
-  SET_GCODE_VARIABLE MACRO=M73 VARIABLE=progress_supported VALUE={false}
+  SET_GCODE_VARIABLE MACRO=M73 VARIABLE=progress_supported VALUE="0"
 
   _BTT_START
   _FD_SET_PRINT_STATS_INFO

--- a/fd-macros/mainsail-support.cfg
+++ b/fd-macros/mainsail-support.cfg
@@ -66,8 +66,10 @@ gcode:
     _BTT_NOTIFY_LAYERLEFT CURRENT={CURRENT_LAYER} MAX={printer.print_stats.info.total_layer | default(0) | int}
   {% endif %}
 
-  {% if printer.virtual_sdcard.file_size is defined and printer.virtual_sdcard.file_size > 0 %}
-    _BTT_NOTIFY_DATALEFT CURRENT={printer.virtual_sdcard.file_position | default(0) | int} MAX={printer.virtual_sdcard.file_size | default(0) | int}
+  {% if not printer["gcode_macro M73"].progress_supported %}
+    {% if printer.virtual_sdcard.file_size is defined and printer.virtual_sdcard.file_size > 0 %}
+      _BTT_NOTIFY_DATALEFT CURRENT={printer.virtual_sdcard.file_position | default(0) | int} MAX={printer.virtual_sdcard.file_size | default(0) | int}
+    {% endif %} 
   {% endif %} 
 
 [gcode_macro _FD_PAUSE]
@@ -121,7 +123,10 @@ description: Internal
   Startcode to prepare a new printing
   triggered by slicer 
 gcode:
+  # Reset states
   CLEAR_PAUSE
+  SET_GCODE_VARIABLE MACRO=M73 VARIABLE=progress_supported VALUE={false}
+
   _BTT_START
   _FD_SET_PRINT_STATS_INFO
 

--- a/fd-macros/mainsail-support.cfg
+++ b/fd-macros/mainsail-support.cfg
@@ -125,7 +125,7 @@ description: Internal
 gcode:
   # Reset states
   CLEAR_PAUSE
-  SET_GCODE_VARIABLE MACRO=M73 VARIABLE=progress_supported VALUE="0"
+  SET_GCODE_VARIABLE MACRO=M73 VARIABLE=progress_supported VALUE=0
 
   _BTT_START
   _FD_SET_PRINT_STATS_INFO


### PR DESCRIPTION
If the slicer put M73 progress commands into the printed gcode file, this progress value is used instead of the formally correct read bytes of the printed file