### PR TITLE
START and PRIME Line rework

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,14 +189,6 @@ Switch to expert mode and configure the following properties:
       START_PRINT BED_TEMP=[first_layer_bed_temperature] EXTRUDER_TEMP=[first_layer_temperature]
       ```
 
-      Optional, you can set-up your length of filament extrusion for your prime line here. Use the parameter `PRIME` for the filament length to be extruded in mm. This is not the length of the line itself.
-
-      Default is 15mm. If you like to disable the prime line, set `PRIME=0` here.
-
-      ```gcode
-      START_PRINT BED_TEMP=[first_layer_bed_temperature] EXTRUDER_TEMP=[first_layer_temperature] PRIME=15
-      ```
-
     - End G-code:
 
       ```gcode

--- a/fd-macros-example.cfg
+++ b/fd-macros-example.cfg
@@ -96,29 +96,28 @@ gcode:
 description: Startcode to prepare a new printing
   triggered by slicer 
 gcode:
-  _FD_SET_STATUSLED STATE="heat"
+  _FD_SET_STATUSLED STATE="ready"
 
   _FD_START_PRINT
 
   #Get Bed and Extruder temperature from Slicer GCode
-  {% set BED_TEMP = params.BED_TEMP| default(60) | float %}
-  {% set EXTRUDER_TEMP = params.EXTRUDER_TEMP| default(200) | float %}  
-  {% set PRIME = params.PRIME | default(15) | float %}  
+  {% set BED_TEMP = params.BED_TEMP | default(60) | float %}
+  {% set EXTRUDER_TEMP = params.EXTRUDER_TEMP | default(200) | float %}
+
+  {% set MIN_X = printer.toolhead.axis_minimum.x | default(0) | float %}
+  {% set MIN_Y = printer.toolhead.axis_minimum.y | default(0) | float %}
 
   M117 Heat Nozzle ({EXTRUDER_TEMP}°C) and Bed ({BED_TEMP}°C)
 
-  SET_HEATER_TEMPERATURE HEATER=heater_bed TARGET={BED_TEMP}  
+  _FD_SET_STATUSLED STATE="heat"  
+  M190 S{BED_TEMP}
+  M104 S{EXTRUDER_TEMP}
 
-  {% if BED_TEMP > 0 %}
-    TEMPERATURE_WAIT SENSOR=heater_bed MINIMUM={BED_TEMP*0.98} MAXIMUM={BED_TEMP*1.02}
-  {% endif %}
-
-  SET_HEATER_TEMPERATURE HEATER=extruder TARGET={EXTRUDER_TEMP}  
-
+  _FD_SET_STATUSLED STATE="home"
   # Init
-  M82 # absolute extrusion mode
-  G92 E0 # reset extruder
+  M83 # relative extrusion mode
   G90 # use absolute coordinates
+  G92 E0 # reset extruder
 
   # Home
   {% if 'xy' in printer.toolhead.homed_axes %}
@@ -127,20 +126,20 @@ gcode:
     G28
   {% endif %}
 
+  G0 X{MIN_X} Y{MIN_Y} Z15 F{50 * 60}
+
   # Use the default bed mesh   
   BED_MESH_PROFILE LOAD=default
   _FD_SET_STATUSLED STATE="heat"
-  _FD_PARK
 
-  TEMPERATURE_WAIT SENSOR=extruder MINIMUM={EXTRUDER_TEMP*0.98} MAXIMUM={EXTRUDER_TEMP*1.02}
+  M109 S{EXTRUDER_TEMP}
 
-  {% if PRIME > 0 %}
-    _FD_PRIME_LINE LENGTH={PRIME}
-  {% endif %}
-  
+  _FD_SET_STATUSLED STATE="prime"  
+  _FD_PRIME_LINE
+
   _FD_SET_STATUSLED STATE="print"
-
-  M117
+  
+  M117 Printing
 
 [gcode_macro END_PRINT]
 description: Endcode to finalize made printing

--- a/fd-macros/bigtreetech-support.cfg
+++ b/fd-macros/bigtreetech-support.cfg
@@ -30,7 +30,7 @@ rename_existing: M27.1
 variable_last_interval: 0
 gcode:
   {% set INTERVAL = params.S | default(0) | float %} #Interval between auto-reports. S0 to disable.
-  {% set FILE = params.C %}
+  {% set FILE = params.C | string %}
 
   M27.1 {rawparams}
   
@@ -96,7 +96,7 @@ description: Set Fan Speed
   Under manual control with an idle machine, M106 will change the fan speed immediately.
 rename_existing: M106.1
 gcode:
-  {% set PERCENTAGE = params.S | default(0) | int %}
+  {% set PERCENTAGE = params.S | default(0) | float %}
   
   M106.1 {rawparams}
   _SEND_TO_BTT COMMAND="M106 S{PERCENTAGE}"
@@ -212,9 +212,9 @@ gcode:
   #{% set E = params.E | default(0)| float %} #E axis max acceleration
 
   {% if params.X is defined %}
-    SET_VELOCITY_LIMIT ACCEL={X} ACCEL_TO_DECEL={X * 2 / 3}
+    SET_VELOCITY_LIMIT ACCEL={X} ACCEL_TO_DECEL={X / 2}
   {% elif params.Y is defined %}
-    SET_VELOCITY_LIMIT ACCEL={Y} ACCEL_TO_DECEL={Y * 2 / 3}
+    SET_VELOCITY_LIMIT ACCEL={Y} ACCEL_TO_DECEL={Y / 2}
   {% endif %}
 
 [gcode_macro M202]
@@ -382,7 +382,7 @@ gcode:
   #Auto Bed Leveling
   _SEND_TO_BTT COMMAND="M420 S1 Z{printer.configfile.settings.bed_mesh.fade_end | default(0)}"
   # Fan Speed
-  _SEND_TO_BTT COMMAND="M106 S{(printer.fan.speed*255) | int}"
+  _SEND_TO_BTT COMMAND="M106 S{(printer.fan.speed | float * 255.0) | float}"
 
 [gcode_macro M524]
 description: Reset SD print

--- a/fd-macros/mainsail-support.cfg
+++ b/fd-macros/mainsail-support.cfg
@@ -85,14 +85,13 @@ variable_last_extruder_temp: 0
 gcode:
   _BTT_RESUME
 
-  # restore extruder temperature
-  SET_HEATER_TEMPERATURE HEATER=extruder TARGET={last_extruder_temp}
-  TEMPERATURE_WAIT SENSOR=extruder MINIMUM={last_extruder_temp*0.98} MAXIMUM={last_extruder_temp*1.02}
+  # restore extruder temperature  
+  M109 S{last_extruder_temp}
 
   SAVE_GCODE_STATE NAME=_fd_resume_state 
   
   M83
-  G1 E1 F1500
+  G1 E1 F2400
 
   RESTORE_GCODE_STATE NAME=_fd_resume_state
 
@@ -153,57 +152,59 @@ gcode:
 
     {% if printer.extruder.can_extrude %}
       M83 # relative extrusion
-      G1 E-1 F1500 # retract filament
+      G1 E-1 F{40 * 60} # retract filament
     {% endif %}
   {% endif %}  
 
   G90 # use absolute coordinates  
-  G1 X{PARK_X} Y{PARK_Y} Z{PARK_Z} F3000 # move to corner of the bed to avoid ooze over centre
+  G1 X{PARK_X} Y{PARK_Y} Z{PARK_Z} F{50 * 60} # move to corner of the bed to avoid ooze over centre
+  G1 X{PARK_X} Y{PARK_Y} Z{PARK_Z} F{50 * 60} # move to corner of the bed to avoid ooze over centre
 
   RESTORE_GCODE_STATE NAME=_fd_park_state 
 
 [gcode_macro _FD_PRIME_LINE]
-description: Draws and cleans the nozzel on start printing
+description: Purges and wipes the Nozzle
 gcode: 
   SAVE_GCODE_STATE NAME=_fd_prime_line_state
-
-  {% set PRIME_LENGTH = params.LENGTH | float %}
 
   {% set MIN_X = printer.toolhead.axis_minimum.x | float %}
   {% set MIN_Y = printer.toolhead.axis_minimum.y | float %}
   {% set MAX_X = printer.toolhead.axis_maximum.x | float %}
   {% set MAX_Y = printer.toolhead.axis_maximum.y | float %}
 
-  {% set NOZZLE = printer.configfile.settings.extruder.nozzle_diameter | float %}
-  {% set FILAMENT = printer.configfile.settings.extruder.filament_diameter | float %}
+  {% set DIAMETER_NOZZLE = printer.configfile.settings.extruder.nozzle_diameter | float %}
+  {% set DIAMETER_FILAMENT = printer.configfile.settings.extruder.filament_diameter | float %}
 
-  {% set HEIGHT = NOZZLE * 0.75 | float %}
-  {% set WIDTH = NOZZLE * 1.50 | float %}
-    
-  {% set FILAMENT_AREA = 3.14159 * (FILAMENT ** 2) / 4.0 | float %}
-  {% set NOZZLE_AREA = WIDTH * HEIGHT | float %}
-  {% set EXTRUSION_VOLUME = FILAMENT_AREA * PRIME_LENGTH | float %}
-  {% set MOVE_LENGTH = EXTRUSION_VOLUME / NOZZLE_AREA | float %}
+  {% set CROSSSECTION_NOZZLE = 3.14159 * DIAMETER_NOZZLE**2 / 4.0 | float %}
+  {% set CROSSSECTION_FILAMENT = 3.14159 * DIAMETER_FILAMENT**2 / 4.0 | float %}
 
-  {% set START_X = MIN_X %}
-  {% set START_Y = (MOVE_LENGTH / 2.0) - 6.0 %}
-  {% set START_Z = HEIGHT %}
-  {% set HALF_X = WIDTH %}
-  {% set HALF_Y = MIN_Y + 3.0 %}
-  {% set END_X = HALF_X %}
-  {% set END_Y = (MOVE_LENGTH / 2.0) + 9.0 %}  
+  {% set EXT_HEIGHT = 0.5 * DIAMETER_NOZZLE | float %}
+  {% set EXT_WIDTH = 3.75 * DIAMETER_NOZZLE**2 / EXT_HEIGHT | float %}
+  {% set EXT_CS = EXT_WIDTH * EXT_HEIGHT | float %}
 
-  M117 Primeline
+  {% set X1 = 7.0 * CROSSSECTION_FILAMENT / EXT_CS / 0.85 %}
+  {% set X2 = 4.0 * CROSSSECTION_FILAMENT / EXT_CS + X1 %}
+  {% set X3 = 4.0 * CROSSSECTION_FILAMENT / EXT_CS + X2 %}
+  {% set X4 = 4.0 * CROSSSECTION_FILAMENT / EXT_CS + X3 %}
+  {% set X5 = 3.0 * CROSSSECTION_FILAMENT / EXT_CS + X4 %}
+  {% set X6 = 3.0 * CROSSSECTION_FILAMENT / EXT_CS + X5 %}
 
-  G90 # use absolute coordinates 
-  G0 X{START_X} Y{START_Y} Z3.0 F3000 ; move to start-line position
-  M82 # E Absolute
-  G92 E0 ; Reset Extruder
-  G0 X{START_X} Y{START_Y} Z{START_Z} F1800 ; Move to start position
-  G1 X{START_X} Y{HALF_Y} E{PRIME_LENGTH * 0.5} F1800 ; Draw primeline
-  G0 X{HALF_X} Y{HALF_Y} F1800
-  G1 X{END_X} Y{END_Y} E{PRIME_LENGTH} F1800 ; Draw primeline
-  # G0 Z3 F1800 ; move z up little to prevent scratching of surface  
-  G92 E0 ; Reset Extruder
+  G90 ; use absolute coordinates
+  G92 E0 ; reset extruder position 
+  M83 # E Relative
+
+  M117 Purge Nozzle  
+
+  G0 X{MIN_X} Y{MIN_Y} Z15 F{30 * 60} ; go to start position
+  G1 E2 F{40 * 60} ; deretraction after the initial one before nozzle cleaning
+  G1 E7 X{X1} Z{EXT_HEIGHT} F{8.5 * 60} ; purge 85%
+  G1 E4 X{X2} F{8.5 * 60} ; purge 100% of max
+  G1 E4 X{X3} F{11.0 * 60} ; purge
+  G1 E4 X{X4} F{13.5 * 60} ; purge
+
+  M117 Wipe Nozzle
+  G0 X{X5} Z0.05 F{130 * 60} ; wipe, move close to the bed
+  G0 X{X6} Z{EXT_HEIGHT} F{130 * 60} ; wipe, move quickly away from the bed
+  G0 Z3 F{10 * 60} ; Prevent scratching
 
   RESTORE_GCODE_STATE NAME=_fd_prime_line_state 

--- a/fd-macros/status-led-support.cfg
+++ b/fd-macros/status-led-support.cfg
@@ -20,21 +20,23 @@ gcode:
   {% if ('neopixel ' ~ LED) in printer.configfile.config or ('dotstar ' ~ LED) in printer.configfile.config %}    
     {% if params.STATE is defined %}
       {% if STATE == 'ready' %}
-        _FD_LED_ANIMATION MODE="static" LED={LED} RED=0 GREEN=1 BLUE=0 # Green
+        _FD_LED_ANIMATION MODE="static" LED={LED} RED={0/255} GREEN={255/255} BLUE={0/255} # Green
       {% elif STATE == 'home' %} 
-        _FD_LED_ANIMATION MODE="static" LED={LED} RED=1 GREEN=0 BLUE=1 # Purple
+        _FD_LED_ANIMATION MODE="static" LED={LED} RED={128/255} GREEN={0/255} BLUE={255/255} # Purple
       {% elif STATE == 'level' %}
-        _FD_LED_ANIMATION MODE="static" LED={LED} RED=1 GREEN=0.25 BLUE=0.65 # DarkPink
+        _FD_LED_ANIMATION MODE="static" LED={LED} RED={255/255} GREEN={128/255} BLUE={0/255} # Orange
       {% elif STATE == 'heat' %}
-        _FD_LED_ANIMATION MODE="static" LED={LED} RED=1 GREEN=1 BLUE=0 # Yellow
+        _FD_LED_ANIMATION MODE="static" LED={LED} RED={255/255} GREEN={255/255} BLUE={0/255} # Yellow
+      {% elif STATE == 'prime' %} 
+        _FD_LED_ANIMATION MODE="static" LED={LED} RED={0/255} GREEN={255/255} BLUE={255/255} # Cyan
       {% elif STATE == 'print' %}
-        _FD_LED_ANIMATION MODE="static" LED={LED} RED=1 GREEN=1 BLUE=1 WHITE=1 # White
+        _FD_LED_ANIMATION MODE="static" LED={LED} RED={255/255} GREEN={255/255} BLUE={255/255} # White
       {% elif STATE == 'pause' %}
-        _FD_LED_ANIMATION MODE="static" LED={LED} RED=0 GREEN=0 BLUE=1 # Blue
+        _FD_LED_ANIMATION MODE="static" LED={LED} RED={0/255} GREEN={0/255} BLUE={255/255} # Blue
       {% elif STATE == 'change' %}
-        _FD_LED_ANIMATION MODE="blink" LED={LED} RED=0 GREEN=0 BLUE=1 # Blue
+        _FD_LED_ANIMATION MODE="blink" LED={LED} RED={0/255} GREEN={0/255} BLUE={255/255} # Blue
       {% elif STATE == 'error' %}
-        _FD_LED_ANIMATION MODE="blink" LED={LED} RED=1 GREEN=0 BLUE=0 # Red
+        _FD_LED_ANIMATION MODE="blink" LED={LED} RED={255/255} GREEN={0/255} BLUE={0/255} # Red
       {% endif %}
     {% endif %}
   {% endif %}


### PR DESCRIPTION
- The Primeline is now enforced. PRIME parameter is obsolete.
- It does a purge and wipe movement inspired by the PRUSA start gcodes.
- More conservative heat up behavior
- Updated Status LED macro

Signed-off-by: Frank Roth developer@freakydu.de